### PR TITLE
BLD: Depend on event-model 1.8.0rc3

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,8 +3,6 @@
 bluesky
 codecov
 coverage
-# TEMPORARY until https://github.com/NSLS-II/event-model/pull/45 is merged
-git+git://github.com/danielballan/event-model@stash-key-on-exception
 flake8
 ophyd
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 dask[bag]
+event_model >=1.8.0rc3
 msgpack
 intake
 intake-xarray


### PR DESCRIPTION
I initially stashed a dev branch dependency in ``requirements-dev.txt`` for
expedience. This is the proper solution.