### PR TITLE
FIX: Two fixes to slicing by recency

### DIFF
--- a/intake_bluesky/jsonl.py
+++ b/intake_bluesky/jsonl.py
@@ -210,11 +210,11 @@ class BlueskyJSONLCatalog(intake.catalog.Catalog):
                                          key=lambda doc: -doc['time'])
                     if N < 0:
                         # Interpret negative N as "the Nth from last entry".
-                        if abs(N) > len(time_sorted):
-                            raise ValueError(
+                        if -N > len(time_sorted):
+                            raise IndexError(
                                 f"Catalog only contains {len(time_sorted)} "
                                 f"runs.")
-                        run_start_doc = time_sorted[N]
+                        run_start_doc = time_sorted[-N - 1]
                     else:
                         # Interpret positive N as
                         # "most recent entry with scan_id == N".

--- a/intake_bluesky/mongo_embedded.py
+++ b/intake_bluesky/mongo_embedded.py
@@ -233,7 +233,7 @@ class BlueskyMongoCatalog(intake.catalog.Catalog):
                         try:
                             header_doc, = cursor
                         except ValueError:
-                            raise ValueError(
+                            raise IndexError(
                                 f"Catalog only contains {len(catalog)} "
                                 f"runs.")
                     else:

--- a/intake_bluesky/mongo_normalized.py
+++ b/intake_bluesky/mongo_normalized.py
@@ -210,7 +210,7 @@ class BlueskyMongoCatalog(intake.catalog.Catalog):
                         try:
                             run_start_doc, = cursor
                         except ValueError:
-                            raise ValueError(
+                            raise IndexError(
                                 f"Catalog only contains {len(catalog)} "
                                 f"runs.")
                     else:

--- a/intake_bluesky/tests/generic.py
+++ b/intake_bluesky/tests/generic.py
@@ -56,7 +56,7 @@ def test_getitem_sugar(bundle):
 
     # Test lookup by recency (e.g. -1 is latest)
     cat[-1]
-    with pytest.raises((ValueError, RemoteCatalogError)):
+    with pytest.raises((IndexError, RemoteCatalogError)):
         cat[-(1 + len(cat))]  # There aren't this many entries
 
     # Test lookup by integer, not globally-unique, 'scan_id'.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 dask[bag]
 event_model >=1.8.0rc3
 msgpack
-intake !=0.4.3
+intake <0.4.3  # change in UserParameters API that we need to adapt to or revert
 intake-xarray
 msgpack
 numpy


### PR DESCRIPTION
- The JSONL catalog was slicing from the wrong end: cat[-1] returned
  oldest instead of newest.
- Slicing beyond the length of the catalog like cat[TOO_BIG] should
  raise an IndexError not a ValueError.