### PR TITLE
REF: Do not use UserParameter. Unpin intake.

### DIFF
--- a/intake_bluesky/core.py
+++ b/intake_bluesky/core.py
@@ -1,4 +1,3 @@
-import ast
 import collections
 import event_model
 from datetime import datetime
@@ -412,9 +411,7 @@ class RunCatalog(intake.catalog.Catalog):
                 get_datum=self._get_datum,
                 get_datum_cursor=self._get_datum_cursor,
                 filler=self.filler,
-                metadata={'descriptors': descriptors},
-                include='{{ include }}',
-                exclude='{{ exclude }}')
+                metadata={'descriptors': descriptors})
             self._entries[stream_name] = intake.catalog.local.LocalCatalogEntry(
                 name=stream_name,
                 description={},  # TODO
@@ -422,7 +419,6 @@ class RunCatalog(intake.catalog.Catalog):
                 direct_access='forbid',
                 args=args,
                 cache=None,  # ???
-                parameters=[_INCLUDE_PARAMETER, _EXCLUDE_PARAMETER],
                 metadata={'descriptors': descriptors},
                 catalog_dir=None,
                 getenv=True,
@@ -493,18 +489,6 @@ class RunCatalog(intake.catalog.Catalog):
             "its entries, representing individual Event Streams.")
 
 
-_EXCLUDE_PARAMETER = intake.catalog.local.UserParameter(
-    name='exclude',
-    description="fields to exclude",
-    type='list',
-    default=None)
-_INCLUDE_PARAMETER = intake.catalog.local.UserParameter(
-    name='include',
-    description="fields to explicitly include at exclusion of all others",
-    type='list',
-    default=None)
-
-
 class BlueskyEventStream(intake_xarray.base.DataSourceMixin):
     """
     Catalog representing one Event Stream from one Run.
@@ -558,8 +542,8 @@ class BlueskyEventStream(intake_xarray.base.DataSourceMixin):
                  get_datum_cursor,
                  filler,
                  metadata,
-                 include,
-                 exclude,
+                 include=None,
+                 exclude=None,
                  **kwargs):
         # self._partition_size = 10
         # self._default_chunks = 10
@@ -575,9 +559,8 @@ class BlueskyEventStream(intake_xarray.base.DataSourceMixin):
         self.filler = filler
         self.urlpath = ''  # TODO Not sure why I had to add this.
         self._ds = None  # set by _open_dataset below
-        # TODO Is there a more direct way to get non-string UserParameters in?
-        self.include = ast.literal_eval(include)
-        self.exclude = ast.literal_eval(exclude)
+        self.include = include
+        self.exclude = exclude
         super().__init__(
             metadata=metadata
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 dask[bag]
 event_model >=1.8.0rc3
 msgpack
-intake !=0.4.3
+intake
 intake-xarray
 msgpack
 numpy


### PR DESCRIPTION
The release of intake 0.4.3 broke our usage of `UserParameter`, which
was never quite correct but happened to work. Our choices are to update
our usage or to drop it altogether and just use `args`. The latter is
simpler, and `UserParameter` was not adding anything in our case.

This PR thus fixes intake-bluesky for intake>=0.4.3 and unpins the
dependency.