### PR TITLE
Two fixes to support reloading.

### DIFF
--- a/intake_bluesky/jsonl.py
+++ b/intake_bluesky/jsonl.py
@@ -259,7 +259,7 @@ class BlueskyJSONLCatalog(intake.catalog.Catalog):
         if self._query:
             query = {'$and': [self._query, query]}
         cat = type(self)(
-            paths=list(self._runs.values()),
+            paths=self.paths,
             query=query,
             name='search results',
             getenv=self.getenv,

--- a/intake_bluesky/jsonl.py
+++ b/intake_bluesky/jsonl.py
@@ -55,7 +55,12 @@ class BlueskyJSONLCatalog(intake.catalog.Catalog):
             file_list = glob.glob(path)
             for run_file in file_list:
                 with open(run_file, 'r') as f:
-                    name, run_start_doc = json.loads(f.readline())
+                    try:
+                        name, run_start_doc = json.loads(f.readline())
+                    except json.JSONDecodeError:
+                        if not f.readline():
+                            # Empty file, maybe being written to currently
+                            continue
 
                     if name != 'start':
                         raise ValueError(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 dask[bag]
 event_model >=1.8.0rc3
 msgpack
-intake
+intake <0.5.0
 intake-xarray
 msgpack
 numpy


### PR DESCRIPTION
When a Catalog is reloaded it needs to discover new .jsonl files that
may have been added. Therefore a search should pass through the raw `paths`
of the original Catalog, which might include directories, instead of a strict
list of specific files. Also, since some files may be currently being
written out by suitcase-jsonl, the Catalog should tolerate and ignore empty
.jsonl files (rather than erroring out).