### PR TITLE
FIX/TST: Handle runs with no descriptors or no events.

### DIFF
--- a/intake_bluesky/core.py
+++ b/intake_bluesky/core.py
@@ -62,13 +62,14 @@ def documents_to_xarray(*, start_doc, stop_doc, descriptor_docs, event_docs,
 
     # Data keys must not change within one stream, so we can safely sample
     # just the first Event Descriptor.
-    data_keys = descriptor_docs[0]['data_keys']
-    if include:
-        keys = list(set(data_keys) & set(include))
-    elif exclude:
-        keys = list(set(data_keys) - set(exclude))
-    else:
-        keys = list(data_keys)
+    if descriptor_docs:
+        data_keys = descriptor_docs[0]['data_keys']
+        if include:
+            keys = list(set(data_keys) & set(include))
+        elif exclude:
+            keys = list(set(data_keys) - set(exclude))
+        else:
+            keys = list(data_keys)
 
     # Collect a Dataset for each descriptor. Merge at the end.
     datasets = []

--- a/intake_bluesky/core.py
+++ b/intake_bluesky/core.py
@@ -76,6 +76,8 @@ def documents_to_xarray(*, start_doc, stop_doc, descriptor_docs, event_docs,
     for descriptor in descriptor_docs:
         events = [doc for doc in event_docs
                   if doc['descriptor'] == descriptor['uid']]
+        if not events:
+            continue
         if any(data_keys[key].get('external') for key in keys):
             for event in events:
                 try:

--- a/intake_bluesky/tests/test_core.py
+++ b/intake_bluesky/tests/test_core.py
@@ -6,7 +6,9 @@ def test_no_descriptors():
     run_bundle = event_model.compose_run()
     start_doc = run_bundle.start_doc
     stop_doc = run_bundle.compose_stop()
-    documents_to_xarray(start_doc=start_doc, stop_doc=stop_doc,
+    documents_to_xarray(
+        start_doc=start_doc,
+        stop_doc=stop_doc,
         descriptor_docs=[],
         event_docs=[],
         filler=event_model.Filler({}),
@@ -23,7 +25,9 @@ def test_no_events():
         name='primary')
     descriptor_doc = desc_bundle.descriptor_doc
     stop_doc = run_bundle.compose_stop()
-    documents_to_xarray(start_doc=start_doc, stop_doc=stop_doc,
+    documents_to_xarray(
+        start_doc=start_doc,
+        stop_doc=stop_doc,
         descriptor_docs=[descriptor_doc],
         event_docs=[],
         filler=event_model.Filler({}),

--- a/intake_bluesky/tests/test_core.py
+++ b/intake_bluesky/tests/test_core.py
@@ -1,0 +1,32 @@
+import event_model
+from intake_bluesky.core import documents_to_xarray
+
+
+def test_no_descriptors():
+    run_bundle = event_model.compose_run()
+    start_doc = run_bundle.start_doc
+    stop_doc = run_bundle.compose_stop()
+    documents_to_xarray(start_doc=start_doc, stop_doc=stop_doc,
+        descriptor_docs=[],
+        event_docs=[],
+        filler=event_model.Filler({}),
+        get_resource=None,
+        get_datum=None,
+        get_datum_cursor=None)
+
+
+def test_no_events():
+    run_bundle = event_model.compose_run()
+    start_doc = run_bundle.start_doc
+    desc_bundle = run_bundle.compose_descriptor(
+        data_keys={'x': {'source': '...', 'shape': [], 'dtype': 'number'}},
+        name='primary')
+    descriptor_doc = desc_bundle.descriptor_doc
+    stop_doc = run_bundle.compose_stop()
+    documents_to_xarray(start_doc=start_doc, stop_doc=stop_doc,
+        descriptor_docs=[descriptor_doc],
+        event_docs=[],
+        filler=event_model.Filler({}),
+        get_resource=None,
+        get_datum=None,
+        get_datum_cursor=None)


### PR DESCRIPTION
This test reproduces the error reported in #27. Snippet:

```python
            # Make DataArrays for Event data.
            for key in keys:
                field_metadata = data_keys[key]
                # Verify the actual ndim by looking at the data.
>               ndim = numpy.asarray(data_table[key][0]).ndim
E               IndexError: list index out of range

intake_bluesky/core.py:109: IndexError
```

It catches another, related case as well.